### PR TITLE
Add new software types

### DIFF
--- a/SoftwareTypes/Artificial Intelligence Software.tyd
+++ b/SoftwareTypes/Artificial Intelligence Software.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Artificial Intelligence Software"
+        Category    Development
+        Description    "Frameworks and tools to build intelligent systems and automate tasks."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    250
+        OptimalDevTime    48
+        SubmarketNames    ["Algorithms"; "Performance"; "Usability"]
+        NameGenerator    ai_software_names.txt
+        Features    [
+            {
+                Name    Machine Learning Libraries
+                Spec    System
+                Description    "Prebuilt algorithms for classification and prediction."
+                DevTime    9
+                CodeArt    0.7
+                Submarkets    [5; 4; 1]
+                Features    [
+                    {
+                        Name    "Neural Network Toolkit"
+                        Level    2
+                        Description    "Modules for building and training neural networks."
+                        DevTime    7
+                        CodeArt    0.8
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Data Preprocessing"
+                        Level    1
+                        Description    "Tools for cleaning and preparing data."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 4; 2]
+                    }
+                ]
+            }
+            {
+                Name    Automation Tools
+                Spec    System
+                Description    "APIs for integrating AI into existing applications."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "Scripting Interface"
+                        Level    1
+                        Description    "Run custom scripts to control AI features."
+                        DevTime    5
+                        CodeArt    0.5
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Model Deployment"
+                        Level    2
+                        Description    "Deploy trained models to production systems."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [5; 3; 2]
+                    }
+                ]
+            }
+            {
+                Name    Visualization Suite
+                Spec    User Interface
+                Description    "Graphical tools for analyzing and presenting AI results."
+                DevTime    7
+                CodeArt    0.5
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Model Insights"
+                        Level    2
+                        Description    "Interactive charts to explore model behavior."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Dashboard Builder"
+                        Level    1
+                        Description    "Create custom dashboards for AI metrics."
+                        DevTime    5
+                        CodeArt    0.5
+                        Submarkets    [3; 3; 4]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Benchmark Software.tyd
+++ b/SoftwareTypes/Benchmark Software.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Benchmark Software"
+        Category    Utility
+        Description    "Measures hardware performance to compare systems."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    40
+        OptimalDevTime    22
+        SubmarketNames    ["Accuracy"; "Performance"; "Usability"]
+        NameGenerator    benchmark_names.txt
+        Features    [
+            {
+                Name    CPU Tests
+                Spec    System
+                Description    "Stress the processor and report benchmark scores."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [5; 4; 1]
+                Features    [
+                    {
+                        Name    "Multi-Core Support"
+                        Level    2
+                        Description    "Tests performance across multiple cores."
+                        DevTime    5
+                        CodeArt    0.7
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Thermal Monitoring"
+                        Level    1
+                        Description    "Records CPU temperature during tests."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    GPU Tests
+                Spec    System
+                Description    "Graphics benchmarks for measuring rendering power."
+                DevTime    7
+                CodeArt    0.6
+                Submarkets    [5; 4; 1]
+                Features    [
+                    {
+                        Name    "Ray Tracing"
+                        Level    2
+                        Description    "Advanced graphics test for ray tracing capabilities."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Frame Rate Test"
+                        Level    1
+                        Description    "Measures average frames per second."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Result Sharing
+                Spec    User Interface
+                Description    "Share benchmark results with friends online."
+                DevTime    4
+                CodeArt    0.4
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Online Leaderboards"
+                        Level    1
+                        Description    "Upload scores to global rankings."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Export Reports"
+                        Level    2
+                        Description    "Generate detailed performance reports in various formats."
+                        DevTime    2
+                        CodeArt    0.4
+                        Submarkets    [2; 3; 5]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Cloud Storage Tool.tyd
+++ b/SoftwareTypes/Cloud Storage Tool.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Cloud Storage Tool"
+        Category    Internet
+        Description    "Service for storing and syncing files across devices."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    60
+        OptimalDevTime    30
+        SubmarketNames    ["Reliability"; "Security"; "Usability"]
+        NameGenerator    cloud_storage_names.txt
+        Features    [
+            {
+                Name    Sync Engine
+                Spec    Network
+                Description    "Reliable background synchronization of files."
+                DevTime    7
+                CodeArt    0.6
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Selective Sync"
+                        Level    1
+                        Description    "Choose specific folders to sync."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Delta Uploads"
+                        Level    2
+                        Description    "Only upload the changed parts of files."
+                        DevTime    5
+                        CodeArt    0.7
+                        Submarkets    [5; 3; 2]
+                    }
+                ]
+            }
+            {
+                Name    Security Features
+                Spec    Security
+                Description    "Protect user data with encryption and access controls."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "End-to-End Encryption"
+                        Level    2
+                        Description    "Encrypt files before they leave the device."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [5; 3; 2]
+                    }
+                    {
+                        Name    "Two-Factor Authentication"
+                        Level    1
+                        Description    "Adds an extra layer of login security."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 4; 2]
+                    }
+                ]
+            }
+            {
+                Name    Collaboration Tools
+                Spec    User Interface
+                Description    "Share files and collaborate with others."
+                DevTime    5
+                CodeArt    0.5
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "File Sharing Links"
+                        Level    1
+                        Description    "Generate shareable download links."
+                        DevTime    2
+                        CodeArt    0.4
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Real-Time Collaboration"
+                        Level    2
+                        Description    "Edit documents simultaneously with others."
+                        DevTime    4
+                        CodeArt    0.6
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Communication Application.tyd
+++ b/SoftwareTypes/Communication Application.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Communication Application"
+        Category    Internet
+        Description    "Messaging and video chat platform for teams and friends."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    50
+        OptimalDevTime    24
+        SubmarketNames    ["Reliability"; "Security"; "User Experience"]
+        NameGenerator    communication_app_names.txt
+        Features    [
+            {
+                Name    Text Chat
+                Spec    Network
+                Description    "Real-time text messaging with emoji and file sharing."
+                DevTime    5
+                CodeArt    0.5
+                Submarkets    [3; 4; 3]
+                Features    [
+                    {
+                        Name    "Group Chats"
+                        Level    1
+                        Description    "Create persistent group conversations."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Message Search"
+                        Level    1
+                        Description    "Quickly search conversation history."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [2; 4; 4]
+                    }
+                ]
+            }
+            {
+                Name    Voice and Video Calls
+                Spec    Network
+                Description    "High-quality calls with screen sharing."
+                DevTime    7
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "Screen Sharing"
+                        Level    1
+                        Description    "Share your desktop in real time."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 4; 2]
+                    }
+                    {
+                        Name    "Background Blur"
+                        Level    2
+                        Description    "Blur the background during video calls for privacy."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [4; 5; 1]
+                    }
+                ]
+            }
+            {
+                Name    Notification System
+                Spec    User Interface
+                Description    "Customizable alerts for messages and calls."
+                DevTime    4
+                CodeArt    0.4
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Do Not Disturb"
+                        Level    1
+                        Description    "Temporarily mute notifications."
+                        DevTime    2
+                        CodeArt    0.3
+                        Submarkets    [2; 3; 5]
+                    }
+                    {
+                        Name    "Notification Scheduling"
+                        Level    2
+                        Description    "Set quiet hours to reduce distractions."
+                        DevTime    3
+                        CodeArt    0.4
+                        Submarkets    [2; 3; 5]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Electronic Flight Bag.tyd
+++ b/SoftwareTypes/Electronic Flight Bag.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Electronic Flight Bag"
+        Category    Utility
+        Description    "Digital toolkit to aid flight crews with planning and navigation."
+        Random    0.2
+        OSSupport    true
+        IdealPrice    200
+        OptimalDevTime    32
+        SubmarketNames    ["Navigation"; "Performance"; "Usability"]
+        NameGenerator    efb_names.txt
+        Features    [
+            {
+                Name    Flight Planning
+                Spec    System
+                Description    "Create and manage flight plans with up-to-date data."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Fuel Calculation"
+                        Level    2
+                        Description    "Estimate fuel requirements based on route and weather."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [5; 3; 2]
+                    }
+                    {
+                        Name    "Route Optimization"
+                        Level    1
+                        Description    "Suggest the most efficient flight path."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 4; 2]
+                    }
+                ]
+            }
+            {
+                Name    Navigation Charts
+                Spec    Data
+                Description    "Digital charts for approach, departure, and en route navigation."
+                DevTime    7
+                CodeArt    0.5
+                Submarkets    [4; 5; 1]
+                Features    [
+                    {
+                        Name    "Automatic Updates"
+                        Level    1
+                        Description    "Keep charts current with regular data cycles."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [4; 5; 1]
+                    }
+                    {
+                        Name    "Night Mode"
+                        Level    2
+                        Description    "Dark theme for low-light cockpit use."
+                        DevTime    3
+                        CodeArt    0.3
+                        Submarkets    [3; 4; 3]
+                    }
+                ]
+            }
+            {
+                Name    Weather Integration
+                Spec    Network
+                Description    "Real-time weather overlays and briefings."
+                DevTime    6
+                CodeArt    0.5
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "METAR/TAF Downloads"
+                        Level    1
+                        Description    "Retrieve latest airport weather reports."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Weather Radar"
+                        Level    2
+                        Description    "Overlay radar imagery on navigation maps."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 5; 1]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/File Archiver.tyd
+++ b/SoftwareTypes/File Archiver.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "File Archiver"
+        Category    Utility
+        Description    "Compress and extract files into various archive formats."
+        Random    0.35
+        OSSupport    true
+        IdealPrice    30
+        OptimalDevTime    16
+        SubmarketNames    ["Compression"; "Security"; "Usability"]
+        NameGenerator    file_archiver_names.txt
+        Features    [
+            {
+                Name    Compression Algorithms
+                Spec    System
+                Description    "Support for multiple algorithms with varying speed and efficiency."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "LZMA"
+                        Level    2
+                        Description    "High compression ratio algorithm."
+                        DevTime    5
+                        CodeArt    0.7
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Fast Compression"
+                        Level    1
+                        Description    "Quick compression with moderate size reduction."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+            {
+                Name    Encryption Support
+                Spec    Security
+                Description    "Protect archives with strong encryption options."
+                DevTime    5
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "Password Protection"
+                        Level    1
+                        Description    "Set passwords on archives to prevent unauthorized access."
+                        DevTime    3
+                        CodeArt    0.6
+                        Submarkets    [4; 4; 2]
+                    }
+                    {
+                        Name    "Keyfile Support"
+                        Level    2
+                        Description    "Use keyfiles for additional security."
+                        DevTime    4
+                        CodeArt    0.6
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Integration Features
+                Spec    User Interface
+                Description    "Seamless integration with file explorers and cloud services."
+                DevTime    4
+                CodeArt    0.4
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Context Menu"
+                        Level    1
+                        Description    "Right-click options for quick archiving."
+                        DevTime    2
+                        CodeArt    0.3
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Cloud Sync"
+                        Level    2
+                        Description    "Direct upload of archives to cloud storage."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Game Engine.tyd
+++ b/SoftwareTypes/Game Engine.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Game Engine"
+        Category    Development
+        Description    "A platform for creating interactive games with advanced physics and graphics."
+        Random    0.2
+        OSSupport    true
+        IdealPrice    200
+        OptimalDevTime    50
+        SubmarketNames    ["Performance"; "Graphics"; "Usability"]
+        NameGenerator    game_engine_names.txt
+        Features    [
+            {
+                Name    Rendering Engine
+                Spec    System
+                Description    "High performance rendering for 2D and 3D games."
+                DevTime    10
+                CodeArt    0.7
+                Submarkets    [5; 4; 1]
+                Features    [
+                    {
+                        Name    "Shader Support"
+                        Level    2
+                        Description    "Allows custom shaders for unique visual effects."
+                        DevTime    6
+                        CodeArt    0.8
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Lighting Engine"
+                        Level    1
+                        Description    "Dynamic lighting and shadow rendering."
+                        DevTime    7
+                        CodeArt    0.6
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Physics Engine
+                Spec    System
+                Description    "Accurate physics simulation for game objects."
+                DevTime    9
+                CodeArt    0.7
+                Submarkets    [4; 5; 1]
+                Features    [
+                    {
+                        Name    "Rigid Body"
+                        Level    1
+                        Description    "Simulates collisions and rigid body dynamics."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [4; 5; 1]
+                    }
+                    {
+                        Name    "Soft Body"
+                        Level    2
+                        Description    "Simulates soft body and cloth interactions."
+                        DevTime    8
+                        CodeArt    0.7
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Tools and Editors
+                Spec    User Interface
+                Description    "Graphical tools for designing levels and scripting gameplay."
+                DevTime    8
+                CodeArt    0.5
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Visual Scripting"
+                        Level    1
+                        Description    "Node-based scripting for rapid prototyping."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Asset Pipeline"
+                        Level    2
+                        Description    "Automated import and management of assets."
+                        DevTime    6
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Integrated Development Environment.tyd
+++ b/SoftwareTypes/Integrated Development Environment.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Integrated Development Environment"
+        Category    Development
+        Description    "A complete environment with tools and editors for efficient software development."
+        Random    0.25
+        OSSupport    true
+        IdealPrice    150
+        OptimalDevTime    42
+        SubmarketNames    ["Performance"; "Extensions"; "Usability"]
+        NameGenerator    ide_names.txt
+        Features    [
+            {
+                Name    Code Editor
+                Spec    System
+                Description    "Powerful editor with syntax highlighting and auto-completion."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [4; 3; 3]
+                Features    [
+                    {
+                        Name    "Refactoring Tools"
+                        Level    2
+                        Description    "Automated tools for code refactoring and cleanup."
+                        DevTime    5
+                        CodeArt    0.7
+                        Submarkets    [4; 4; 2]
+                    }
+                    {
+                        Name    "Version Control Integration"
+                        Level    1
+                        Description    "Built-in support for popular version control systems."
+                        DevTime    4
+                        CodeArt    0.6
+                        Submarkets    [3; 4; 3]
+                    }
+                ]
+            }
+            {
+                Name    Debugger
+                Spec    System
+                Description    "Integrated debugger with breakpoints and variable inspection."
+                DevTime    7
+                CodeArt    0.7
+                Submarkets    [4; 3; 3]
+                Features    [
+                    {
+                        Name    "Memory Profiler"
+                        Level    1
+                        Description    "Analyzes application memory usage."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Remote Debugging"
+                        Level    2
+                        Description    "Debug applications running on remote environments."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [4; 4; 2]
+                    }
+                ]
+            }
+            {
+                Name    Extension System
+                Spec    User Interface
+                Description    "Allows developers to extend the IDE with plugins."
+                DevTime    6
+                CodeArt    0.5
+                Submarkets    [3; 4; 3]
+                Features    [
+                    {
+                        Name    "Marketplace"
+                        Level    1
+                        Description    "Central repository for discovering and installing extensions."
+                        DevTime    5
+                        CodeArt    0.5
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Scripting API"
+                        Level    2
+                        Description    "API for automating and customizing IDE behaviors."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Livestreaming Software.tyd
+++ b/SoftwareTypes/Livestreaming Software.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Livestreaming Software"
+        Category    Multimedia
+        Description    "Broadcast gameplay or presentations live to an online audience."
+        Random    0.25
+        OSSupport    true
+        IdealPrice    80
+        OptimalDevTime    28
+        SubmarketNames    ["Performance"; "Stability"; "User Experience"]
+        NameGenerator    livestreaming_names.txt
+        Features    [
+            {
+                Name    Capture Engine
+                Spec    System
+                Description    "Captures high-resolution video and audio with minimal impact on performance."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Game Capture"
+                        Level    1
+                        Description    "Optimized capturing for fullscreen games."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [5; 3; 2]
+                    }
+                    {
+                        Name    "Window Capture"
+                        Level    1
+                        Description    "Capture specific application windows."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+            {
+                Name    Streaming Tools
+                Spec    Network
+                Description    "Built-in integration with popular streaming platforms."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "Chat Overlay"
+                        Level    1
+                        Description    "Display chat messages over the stream."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [3; 4; 3]
+                    }
+                    {
+                        Name    "Alerts System"
+                        Level    2
+                        Description    "Custom alerts for followers and donations."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 5; 1]
+                    }
+                ]
+            }
+            {
+                Name    Recording Options
+                Spec    System
+                Description    "Record high-quality footage while streaming."
+                DevTime    5
+                CodeArt    0.5
+                Submarkets    [4; 3; 3]
+                Features    [
+                    {
+                        Name    "Local Recording"
+                        Level    1
+                        Description    "Save recordings directly to disk."
+                        DevTime    3
+                        CodeArt    0.4
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Replay Buffer"
+                        Level    2
+                        Description    "Capture the last moments of gameplay for highlights."
+                        DevTime    4
+                        CodeArt    0.6
+                        Submarkets    [5; 3; 2]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Mapping Application.tyd
+++ b/SoftwareTypes/Mapping Application.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Mapping Application"
+        Category    Utility
+        Description    "Navigation tool with detailed maps and route planning."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    25
+        OptimalDevTime    20
+        SubmarketNames    ["Coverage"; "Accuracy"; "Usability"]
+        NameGenerator    mapping_app_names.txt
+        Features    [
+            {
+                Name    Map Data
+                Spec    Data
+                Description    "High resolution maps with regular updates."
+                DevTime    7
+                CodeArt    0.5
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Offline Maps"
+                        Level    1
+                        Description    "Download regions for offline navigation."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Traffic Information"
+                        Level    2
+                        Description    "Real-time traffic and incident reporting."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Routing Engine
+                Spec    System
+                Description    "Calculates optimal routes for driving, biking, or walking."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "Multi-stop Planning"
+                        Level    1
+                        Description    "Add multiple destinations to a single trip."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Public Transit Routes"
+                        Level    2
+                        Description    "Includes bus and train schedules in route suggestions."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [5; 3; 2]
+                    }
+                ]
+            }
+            {
+                Name    Points of Interest
+                Spec    User Interface
+                Description    "Discover restaurants, attractions, and services nearby."
+                DevTime    5
+                CodeArt    0.4
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Reviews and Ratings"
+                        Level    1
+                        Description    "User reviews help choose the best places."
+                        DevTime    3
+                        CodeArt    0.3
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Favorites"
+                        Level    2
+                        Description    "Save frequently visited locations for quick access."
+                        DevTime    2
+                        CodeArt    0.3
+                        Submarkets    [2; 3; 5]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Robot Software.tyd
+++ b/SoftwareTypes/Robot Software.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Robot Software"
+        Category    Utility
+        Description    "Software to control and automate robotic hardware."
+        Random    0.25
+        OSSupport    true
+        IdealPrice    300
+        OptimalDevTime    45
+        SubmarketNames    ["Control"; "Sensors"; "Usability"]
+        NameGenerator    robot_software_names.txt
+        Features    [
+            {
+                Name    Motion Control
+                Spec    System
+                Description    "Precise movement and path planning for robots."
+                DevTime    9
+                CodeArt    0.7
+                Submarkets    [5; 4; 1]
+                Features    [
+                    {
+                        Name    "Inverse Kinematics"
+                        Level    2
+                        Description    "Calculate joint positions for end effector control."
+                        DevTime    7
+                        CodeArt    0.8
+                        Submarkets    [6; 3; 1]
+                    }
+                    {
+                        Name    "Trajectory Planning"
+                        Level    1
+                        Description    "Generate smooth movement paths."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Sensor Integration
+                Spec    System
+                Description    "Interfaces for cameras, lidar, and other sensors."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [4; 5; 1]
+                Features    [
+                    {
+                        Name    "Sensor Calibration"
+                        Level    1
+                        Description    "Tools for calibrating sensors and removing noise."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [4; 5; 1]
+                    }
+                    {
+                        Name    "Sensor Fusion"
+                        Level    2
+                        Description    "Combine data from multiple sensors for accurate perception."
+                        DevTime    7
+                        CodeArt    0.7
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Programming Interface
+                Spec    User Interface
+                Description    "Graphical and script-based programming options."
+                DevTime    6
+                CodeArt    0.5
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Visual Programming"
+                        Level    1
+                        Description    "Drag-and-drop interface for beginners."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Script Editor"
+                        Level    2
+                        Description    "Advanced scripting for complex behaviors."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Streaming Service.tyd
+++ b/SoftwareTypes/Streaming Service.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Streaming Service"
+        Category    Internet
+        Description    "Online platform for streaming music, movies, and TV shows."
+        Random    0.2
+        OSSupport    true
+        IdealPrice    10
+        OptimalDevTime    36
+        SubmarketNames    ["Content"; "Performance"; "User Experience"]
+        NameGenerator    streaming_service_names.txt
+        Features    [
+            {
+                Name    Content Library
+                Spec    Data
+                Description    "Curated collection of audio and video content."
+                DevTime    7
+                CodeArt    0.5
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Recommendations"
+                        Level    1
+                        Description    "Personalized content suggestions."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                    {
+                        Name    "Offline Mode"
+                        Level    2
+                        Description    "Allows temporary downloads for offline viewing."
+                        DevTime    6
+                        CodeArt    0.6
+                        Submarkets    [5; 3; 2]
+                    }
+                ]
+            }
+            {
+                Name    Streaming Quality
+                Spec    Network
+                Description    "Adaptive streaming for different connection speeds."
+                DevTime    6
+                CodeArt    0.6
+                Submarkets    [4; 4; 2]
+                Features    [
+                    {
+                        Name    "HD Support"
+                        Level    1
+                        Description    "High-definition video playback."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [4; 4; 2]
+                    }
+                    {
+                        Name    "4K Support"
+                        Level    2
+                        Description    "Ultra high-definition streaming for supported content."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Subscription System
+                Spec    System
+                Description    "Manage user subscriptions and payment plans."
+                DevTime    5
+                CodeArt    0.4
+                Submarkets    [3; 3; 4]
+                Features    [
+                    {
+                        Name    "Family Plans"
+                        Level    1
+                        Description    "Multiple profiles under one subscription."
+                        DevTime    4
+                        CodeArt    0.4
+                        Submarkets    [3; 3; 4]
+                    }
+                    {
+                        Name    "Gift Cards"
+                        Level    2
+                        Description    "Support redeemable codes for gift subscriptions."
+                        DevTime    3
+                        CodeArt    0.3
+                        Submarkets    [2; 3; 5]
+                    }
+                ]
+            }
+        ]
+    }

--- a/SoftwareTypes/Video Editor.tyd
+++ b/SoftwareTypes/Video Editor.tyd
@@ -1,0 +1,92 @@
+SoftwareType
+    {
+        Name    "Video Editor"
+        Category    Multimedia
+        Description    "A comprehensive suite for editing and producing professional-quality videos."
+        Random    0.3
+        OSSupport    true
+        IdealPrice    120
+        OptimalDevTime    40
+        SubmarketNames    ["Performance"; "Effects"; "User Interface"]
+        NameGenerator    video_editor_names.txt
+        Features    [
+            {
+                Name    Timeline Editing
+                Spec    User Interface
+                Description    "Non-linear editing with a multi-track timeline."
+                DevTime    8
+                CodeArt    0.6
+                Submarkets    [5; 3; 2]
+                Features    [
+                    {
+                        Name    "Keyframe Animation"
+                        Level    2
+                        Description    "Animate properties over time with precision keyframes."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [5; 2; 3]
+                    }
+                    {
+                        Name    "Multi-track Support"
+                        Level    1
+                        Description    "Edit multiple video and audio tracks simultaneously."
+                        DevTime    4
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+            {
+                Name    Visual Effects
+                Spec    Video
+                Description    "Built-in library of effects and color tools."
+                DevTime    7
+                CodeArt    0.7
+                Submarkets    [4; 5; 1]
+                Features    [
+                    {
+                        Name    "Color Grading"
+                        Level    2
+                        Description    "Advanced color correction and grading workspace."
+                        DevTime    5
+                        CodeArt    0.6
+                        Submarkets    [4; 5; 1]
+                    }
+                    {
+                        Name    "Chroma Key"
+                        Level    1
+                        Description    "Remove backgrounds using green screen technology."
+                        DevTime    6
+                        CodeArt    0.7
+                        Submarkets    [5; 4; 1]
+                    }
+                ]
+            }
+            {
+                Name    Export Options
+                Spec    System
+                Description    "Render videos in numerous formats and resolutions."
+                DevTime    5
+                CodeArt    0.4
+                Submarkets    [3; 2; 5]
+                Features    [
+                    {
+                        Name    "GPU Acceleration"
+                        Level    2
+                        Description    "Use GPU hardware to speed up rendering."
+                        DevTime    4
+                        CodeArt    0.7
+                        Submarkets    [5; 3; 2]
+                    }
+                    {
+                        Name    "Preset Templates"
+                        Level    1
+                        Description    "Ready-made export profiles for popular platforms."
+                        DevTime    3
+                        CodeArt    0.5
+                        Submarkets    [4; 3; 3]
+                    }
+                ]
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- expand the mod with several software types: Video Editor, Game Engine, IDE, Communication Application, Livestreaming, Streaming Service, AI, File Archiver, Mapping App, Cloud Storage, Robot Software, Electronic Flight Bag and Benchmark Software
- each type includes detailed feature lists to mirror the existing style

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684004a315a0832ebd41dd08ea48901c